### PR TITLE
Suppress duplicated result output

### DIFF
--- a/otpl-service-check
+++ b/otpl-service-check
@@ -14,7 +14,7 @@ import requests
 discotimeout = 4 # In seconds.
 tokenkey = 'server-token'
 # NB: Version is duplicated in setup.py.
-useragent = 'otpl-service-check/1.0.4'
+useragent = 'otpl-service-check/1.0.5'
 
 Result = namedtuple('Result', ('code', 'message'))
 

--- a/otpl-service-check
+++ b/otpl-service-check
@@ -96,6 +96,9 @@ class Main(object):
         'warn-fewer must be at least as large as critical-fewer')
 
     self.args = args
+    
+    # track output we've already seen and remove dupes
+    self.response_data_seen = set()
 
   def parser_error(self, message):
     # Code 3 is "UNKNOWN".  (argparse default is 2, which would be
@@ -143,14 +146,17 @@ class Main(object):
       count, self.args.critical_fewer, self.args.warn_fewer)
     return self.make_result(code, 'announcements', msg)
 
-  @classmethod
   def make_response_result(
-      cls, code, uri, status_code, duration, contenttype, text):
+      self, code, uri, status_code, duration, contenttype, text):
     msg = '%s from endpoint' % status_code
     if code != 0:
+      if text in self.response_data_seen:
+        # extra leading space on next line is important so it sorts after real results
+        return self.make_result(code, 'health', " <duplicate '%s'>" % uri)
       msg += '\n' + Parser.parse(contenttype, text)
+      self.response_data_seen.add(text)
     msg += '\nduration %.3fs' % duration
-    return cls.make_response_with_uri(code, 'health', uri, msg)
+    return self.make_response_with_uri(code, 'health', uri, msg)
 
   def make_timeout_result(self, uri, type):
     return self.make_response_with_uri(

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name="otpl-service-check",
     description="A selection of Nagios plugins to monitor services hosted in OpenTable Mesos.",
     long_description=open('README.rst').read(),
-    version="1.0.4", # NB: Version is duplicated in otpl-service-check.
+    version="1.0.5", # NB: Version is duplicated in otpl-service-check.
     packages=find_packages(),
     author='OpenTable Architecture Team',
     author_email='archteam@opentable.onmicrosoft.com',


### PR DESCRIPTION
Now it looks like:

```
health warning: 400 from endpoint
{
  "flapDetector": {
    "healthy": false, 
    "message": "WARN: gc-inventory-reporting: saw 180 updates, saw 179 deletes ; swagger-ui: saw 180 updates, saw 179 deletes ; loyalty-service: saw 91 updates, saw 91 deletes ; reviews-api: saw 64 updates, saw 64 deletes ; reviews-reports-service: saw 64 updates, saw 64 deletes"
  }
}
duration 0.057s
check URI http://mesos-slave17-qa-uswest2.qasql.opentable.com:31694/health
---
health warning:  <ditto 'http://mesos-slave20-qa-uswest2.qasql.opentable.com:31029/health'>
---
health warning:  <ditto 'http://mesos-slave15-qa-uswest2.qasql.opentable.com:31004/health'>
---
announcements ok: 3
crit./warn thresh.: 2/2
---
```