### PR TITLE
Fix KeyError if service doesn't send back Content-Type header

### DIFF
--- a/otpl-service-check
+++ b/otpl-service-check
@@ -25,10 +25,11 @@ class Parser(object):
   parsers = {} # lower-case content type prefix -> parser class
   @classmethod
   def parse(cls, contenttype, text):
-    contenttype = contenttype.lower()
-    for prefix, parsercls in cls.parsers.iteritems():
-      if contenttype.startswith(prefix):
-        return parsercls().parse(text)
+    if contenttype is not None:
+      contenttype = contenttype.lower()
+      for prefix, parsercls in cls.parsers.iteritems():
+        if contenttype.startswith(prefix):
+          return parsercls().parse(text)
     return DefaultParser().parse(text)
 
 class LimitedParser(Parser):
@@ -173,7 +174,7 @@ class Main(object):
       duration = time.time() - start
       statuscode = resp.status_code
       code = statuscode // 100
-      contenttype = resp.headers['content-type']
+      contenttype = resp.headers.get('content-type')
       text = resp.text
       if code == 2:
         return self.make_response_result(


### PR DESCRIPTION
```
unhandled exception
Traceback (most recent call last):
  File "./otpl-service-check", line 228, in <module>
    sys.exit(Main().run())
  File "./otpl-service-check", line 217, in run
    res = self.check_endpoint(ann)
  File "./otpl-service-check", line 176, in check_endpoint
    contenttype = resp.headers['content-type']
  File "/usr/local/lib/python2.7/site-packages/requests/structures.py", line 56, in __getitem__
    return self._store[key.lower()][1]
KeyError: 'content-type'
```